### PR TITLE
Set Content-Type header

### DIFF
--- a/example_nginx.conf
+++ b/example_nginx.conf
@@ -24,6 +24,7 @@ server {
 	location ~* \/(polling|callback|staging).* {
 		proxy_pass    http://127.0.0.1:3000;
 		proxy_read_timeout  3600;
+		add_header Content-Type text/css;
     }
 		
     ssl_certificate     /path/to/your/wildcard/cert/goes/here/fullchain.pem;


### PR DESCRIPTION
This fixes an issue I encountered on IE, where the header needs to be explicitly set.